### PR TITLE
fix: TRP3 2.5.0 event API compatibility

### DIFF
--- a/.script/deploy_development.sh
+++ b/.script/deploy_development.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 9.0.2
+curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 10.1.0
 curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 1.13.5
 
 curlfiles=""

--- a/.script/deploy_release.sh
+++ b/.script/deploy_release.sh
@@ -1,2 +1,2 @@
-curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -p 297044 -g 9.0.2
+curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -p 297044 -g 10.1.0
 curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -p 297044 -g 1.13.5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Changes for version 1.13
+- Retail toc bumped
+
+## Fixed
+- TRP3 Event API compatibility restored
+
 # Changes for version 1.12
 - Retail toc bumped
 

--- a/TRP3LocationToggle.lua
+++ b/TRP3LocationToggle.lua
@@ -22,7 +22,7 @@ local function onStart()
     local tooltip_loc_shown = format(loc.ADDON_LOCTOGGLE_tooltip_visible, color("g"))
     local tooltip_loc_hidden = format(loc.ADDON_LOCTOGGLE_tooltip_hidden, color("r"))
 
-    TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
+    TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_LOADED, function()
         if not TRP3_API.toolbar then
             TRP3_API.utils.message.displayMessage(color("r").."The 'Toolbar' module must be enabled for Location Toggle to work!")
             return
@@ -70,7 +70,7 @@ local function onStart()
 
     end)
 
-    TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_FINISH, function()
+    TRP3_API.RegisterCallback(TRP3_Addon, TRP3_Addon.Events.WORKFLOW_ON_FINISH, function()
         -- As of TRP 1.5.0 'register_map_location' isn't always loaded until after we're initialized
         registerConfigHandler({'register_map_location'}, function()
             location_setting_updated = true
@@ -84,8 +84,8 @@ end
 TRP3_API.module.registerModule({
     ["name"] = "Location Toggle",
     ["description"] = "Adds a toolbar button to quickly enable/disable map location.",
-    ["version"] = 1.12,
+    ["version"] = 1.13,
     ["id"] = "trp_location_toggle",
     ["onStart"] = onStart,
-    ["minVersion"] = 3,    
+    ["minVersion"] = 3,
 })

--- a/TRP3LocationToggle.toc
+++ b/TRP3LocationToggle.toc
@@ -1,5 +1,5 @@
 #@retail@
-## Interface: 90002
+## Interface: 100100
 #@end-retail@
 #@non-retail@
 # ## Interface: 11305


### PR DESCRIPTION
Changes introduced by Total-RP/Total-RP-3#710 caused the addon to malfunction at loading:

> [TotalRP3] Error while loading module "trp_location_toggle": ...ace/AddOns/TRP3LocationToggle/TRP3LocationToggle.lua:25: attempt to index field 'Events' (a nil value)

fixes #3, fixes #5, fixes #6